### PR TITLE
Add link to detailed blog post

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,3 +9,5 @@ browserify test.js node_modules/browserstack-tape-reporter/index.js -o test.buil
 And launch the [browserstack-runner](https://github.com/browserstack/browserstack-runner) pointed at an html file that loads `test.build.js`.
 
 Requires tape >=4.1.0 and browserstack-runner >=0.3.7.
+
+More info can be found in [this blog post](http://joshduff.com/#!/post/2015-08-automated-testing-with-tape-and-browserstack.md).


### PR DESCRIPTION
@TehShrike After I opened [this issue](https://github.com/TehShrike/browserstack-tape-reporter/issues/1) I found this [blog post](http://joshduff.com/#!/post/2015-08-automated-testing-with-tape-and-browserstack.md) in a search engine, and it helped me resolve my problem.  I think it would be nice to add this link directly in the README.
